### PR TITLE
pty: Handle terminal ioctls to master pty using libtty

### DIFF
--- a/pty.c
+++ b/pty.c
@@ -557,6 +557,7 @@ static request_t *ptm_devctl_op(object_t *o, request_t *r)
 
 	in_data = ioctl_unpack(&r->msg, &request, NULL);
 
+	mutexLock(pty->mutex);
 	PTY_TRACE("ptm_devctl request: %lx", request);
 
 	switch (request) {
@@ -576,13 +577,14 @@ static request_t *ptm_devctl_op(object_t *o, request_t *r)
 			err = EOK;
 		}
 		break;
-
 	default:
-		log_error("invalid request %x", request);
+		err = libtty_ioctl(&pty->tty, r->msg.pid, request, in_data, &out_data);
 		break;
 	}
+	mutexUnlock(pty->mutex);
 
 	ioctl_setResponse(&r->msg, request, err, out_data);
+
 	return r;
 }
 


### PR DESCRIPTION
JIRA: DTR-226

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dropbear and telnet used to cause posixsrv errors because of not handling TIOCSWINSZ, TCGETS ioctls. Now those ioctls are handled inside libtty and they affect the pseudoterminal's attributes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
