### PR TITLE
pty: add baudrate to libtty_init function

### DIFF
--- a/pty.c
+++ b/pty.c
@@ -630,7 +630,7 @@ static int ptm_create(int *id)
 	mutexCreate(&pty->mutex);
 	condCreate(&pty->cond);
 
-	if (libtty_init(&pty->tty, &pty->ops, _PAGE_SIZE) < 0) {
+	if (libtty_init(&pty->tty, &pty->ops, _PAGE_SIZE, TTYDEF_SPEED) < 0) {
 		log_error("libtty_init");
 		free(pty);
 		return -ENOMEM;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
RTOS-259

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/301).
- [ ] I will merge this PR by myself when appropriate.
