### PR TITLE
posixsrv: add the support for disabling /dev/urandom file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ include ../phoenix-rtos-build/Makefile.common
 NAME := posixsrv
 SRCS := $(wildcard *.c)
 LIBS := libtty
+
+# special flag depends on project
+ifeq ($(POSIXSRV_PRNG), n)
+	LOCAL_CFLAGS += -DNOPRNG
+endif
+
 include $(binary.mk)
 
 ALL_COMPONENTS := posixsrv

--- a/special.c
+++ b/special.c
@@ -61,6 +61,7 @@ static request_t *zero_read_op(object_t *o, request_t *r)
 }
 
 
+#ifndef NOPRNG
 static request_t *random_read_op(object_t *o, request_t *r)
 {
 	int len = r->msg.o.size;
@@ -80,6 +81,7 @@ static request_t *random_read_op(object_t *o, request_t *r)
 	rq_setResponse(r, r->msg.o.size);
 	return r;
 }
+#endif
 
 
 static request_t *null_getattr_op(object_t *o, request_t *r)
@@ -132,6 +134,8 @@ static operations_t zero_ops = {
 	.release = (void *)free,
 };
 
+
+#ifndef NOPRNG
 static operations_t random_ops = {
 	.handlers = { NULL },
 	.open = nothing_op,
@@ -141,6 +145,7 @@ static operations_t random_ops = {
 	.getattr = zero_getattr_op,
 	.release = (void *)free,
 };
+#endif
 
 
 int special_init()
@@ -165,10 +170,12 @@ int special_init()
 	if ((o = malloc(sizeof(*o))) == NULL)
 		return -ENOMEM;
 
+#ifndef NOPRNG
 	srand(time(NULL));
 	object_create(o, &random_ops);
 	err = object_link(o, "/dev/urandom");
 	object_put(o);
+#endif
 
 	return err;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add macros in special.c which will be able to disable `/dev/urandom` if the special bariable is set in config file for a target.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
