### PR TITLE
posixsrv: allow building as library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,18 @@ include ../phoenix-rtos-build/Makefile.common
 
 .DEFAULT_GOAL := all
 
+NAME := libposixsrv
+SRCS := $(filter-out srv.c, $(wildcard *.c))
+HEADERS := posixsrv.h
+include $(static-lib.mk)
+
 # single component in this whole repo
 NAME := posixsrv
 SRCS := $(wildcard *.c)
 LIBS := libtty
 include $(binary.mk)
 
-ALL_COMPONENTS := posixsrv
+ALL_COMPONENTS := posixsrv libposixsrv
 DEFAULT_COMPONENTS := $(ALL_COMPONENTS)
 
 # create generic targets

--- a/event.c
+++ b/event.c
@@ -881,10 +881,11 @@ static int event_object_link(object_t *o, char *path)
 }
 
 
-int event_init(void)
+int event_init(unsigned *port)
 {
-	if (mutexCreate(&event_common.lock) < 0)
+	if (mutexCreate(&event_common.lock) < 0) {
 		return -ENOMEM;
+	}
 
 	portCreate(&event_common.port);
 
@@ -897,5 +898,9 @@ int event_init(void)
 	event_object_link(&event_common.sink, "/dev/event/sink");
 	event_object_link(&event_common.qmx, "/dev/event/queue");
 
-	return event_common.port;
+	if (port != NULL) {
+		*port = event_common.port;
+	}
+
+	return 0;
 }

--- a/posixsrv.c
+++ b/posixsrv.c
@@ -62,13 +62,13 @@ static void fail(const char *str)
 }
 
 
-void object_destroy(object_t *o)
+void posixsrv_object_destroy(object_t *o)
 {
 	o->destroy = 1;
 }
 
 
-object_t *object_get(int id)
+object_t *posixsrv_object_get(int id)
 {
 	object_t *o;
 
@@ -96,7 +96,7 @@ object_t *object_get(int id)
 }
 
 
-void object_ref(object_t *o)
+void posixsrv_object_ref(object_t *o)
 {
 	while (mutexLock(posixsrv_common.lock) < 0);
 	o->refs++;
@@ -104,7 +104,7 @@ void object_ref(object_t *o)
 }
 
 
-void object_put(object_t *o)
+void posixsrv_object_put(object_t *o)
 {
 	while (mutexLock(posixsrv_common.lock) < 0);
 
@@ -128,7 +128,7 @@ void object_put(object_t *o)
 }
 
 
-int object_create(object_t *o, const operations_t *ops)
+int posixsrv_object_create(object_t *o, const operations_t *ops)
 {
 	o->destroy = 0;
 	o->operations = ops;
@@ -146,7 +146,7 @@ int object_create(object_t *o, const operations_t *ops)
 }
 
 
-int object_link(object_t *o, const char *path)
+int posixsrv_object_link(object_t *o, const char *path)
 {
 	TRACE("linking %d to %s", o->linkage.id, path);
 	oid_t oid;
@@ -158,7 +158,7 @@ int object_link(object_t *o, const char *path)
 }
 
 
-unsigned srv_port(void)
+unsigned posixsrv_port(void)
 {
 	return posixsrv_common.port;
 }
@@ -329,12 +329,12 @@ void posixsrvthr(void *arg)
 		if (msgRecv(port, &r->msg, &r->rid) < 0)
 			continue;
 
-		o = object_get(rq_id(r));
+		o = posixsrv_object_get(rq_id(r));
 
 		/* Can't handle msg - wrong object id or wrong operation */
 		if (o == NULL || o->operations->handlers[r->msg.type] == NULL) {
 			if (o != NULL)
-				object_put(o);
+				posixsrv_object_put(o);
 			r->msg.o.io.err = -EINVAL;
 			msgRespond(port, &r->msg, r->rid);
 			continue;
@@ -348,7 +348,7 @@ void posixsrvthr(void *arg)
 		if (r != NULL)
 			msgRespond(port, &r->msg, r->rid);
 
-		object_put(o);
+		posixsrv_object_put(o);
 	}
 }
 

--- a/posixsrv.h
+++ b/posixsrv.h
@@ -23,10 +23,10 @@ int posixsrv_init(unsigned *srvPort, unsigned *eventPort);
 unsigned posixsrv_port(void);
 
 
-void posixsrvthr(void *arg);
+void posixsrv_threadMain(void *arg);
 
 
-void rq_timeoutthr(void *arg);
+void posixsrv_threadRqTimeout(void *arg);
 
 
 #endif /* end of POSIXSRV_H */

--- a/posixsrv.h
+++ b/posixsrv.h
@@ -1,0 +1,32 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * POSIX server - public api
+ *
+ * Copyright 2018, 2023 Phoenix Systems
+ * Author: Jan Sikorski, Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef POSIXSRV_H
+#define POSIXSRV_H
+
+
+int posixsrv_init(unsigned *srvPort, unsigned *eventPort);
+
+
+unsigned posixsrv_port(void);
+
+
+void posixsrvthr(void *arg);
+
+
+void rq_timeoutthr(void *arg);
+
+
+#endif /* end of POSIXSRV_H */

--- a/posixsrv_private.h
+++ b/posixsrv_private.h
@@ -100,31 +100,31 @@ extern void rq_timeout(request_t *r, int timeout);
 extern int rq_id(request_t *r);
 
 
-extern unsigned srv_port(void);
+extern unsigned posixsrv_port(void);
 
 
-extern int object_link(object_t *o, const char *path);
+extern int posixsrv_object_link(object_t *o, const char *path);
 
 
-static inline int object_id(object_t *o)
+static inline int posixsrv_object_id(object_t *o)
 {
 	return o->linkage.id;
 }
 
 
-extern void object_destroy(object_t *o);
+extern void posixsrv_object_destroy(object_t *o);
 
 
-extern object_t *object_get(int id);
+extern object_t *posixsrv_object_get(int id);
 
 
-extern void object_ref(object_t *o);
+extern void posixsrv_object_ref(object_t *o);
 
 
-extern void object_put(object_t *o);
+extern void posixsrv_object_put(object_t *o);
 
 
-extern int object_create(object_t *o, const operations_t *ops);
+extern int posixsrv_object_create(object_t *o, const operations_t *ops);
 
 
 extern int pipe_create(int type, int *id, unsigned open);

--- a/posixsrv_private.h
+++ b/posixsrv_private.h
@@ -145,7 +145,7 @@ extern int pty_init(void);
 extern int special_init(void);
 
 
-extern int event_init(void);
+extern int event_init(unsigned *port);
 
 
 extern int tmpfile_init(void);

--- a/special.c
+++ b/special.c
@@ -35,7 +35,7 @@
 
 static request_t *special_link(object_t *o, request_t *r)
 {
-	object_ref(o);
+	posixsrv_object_ref(o);
 	rq_setResponse(r, 0);
 	return r;
 }
@@ -43,7 +43,7 @@ static request_t *special_link(object_t *o, request_t *r)
 
 static request_t *special_unlink(object_t *o, request_t *r)
 {
-	object_put(o);
+	posixsrv_object_put(o);
 	rq_setResponse(r, 0);
 	return r;
 }
@@ -189,19 +189,19 @@ static int special_createFile(const char *path, const operations_t *ops)
 		return -ENOMEM;
 	}
 
-	err = object_create(o, ops);
+	err = posixsrv_object_create(o, ops);
 	if (err < 0) {
 		free(o);
 		return err;
 	}
 
-	err = object_link(o, path);
+	err = posixsrv_object_link(o, path);
 	if (err < 0) {
-		object_put(o);
+		posixsrv_object_put(o);
 		return err;
 	}
 
-	object_put(o);
+	posixsrv_object_put(o);
 
 	return 0;
 }

--- a/srv.c
+++ b/srv.c
@@ -38,26 +38,26 @@ static int fail(const char *str)
 int main(int argc, char **argv)
 {
 	oid_t fs;
-	unsigned port;
-	unsigned events_port;
+	unsigned srvPort;
+	unsigned eventPort;
 
 	while (lookup("/", NULL, &fs) < 0) {
 		usleep(5000);
 	}
 
-	if (posixsrv_init(&port, &events_port) < 0) {
+	if (posixsrv_init(&srvPort, &eventPort) < 0) {
 		fail("srv init");
 	}
 
 	openlog("posixsrv", LOG_CONS, LOG_DAEMON);
 
-	beginthread(posixsrvthr, 4, stacks[0], sizeof(stacks[0]), (void *)events_port);
+	beginthread(posixsrv_threadMain, 4, stacks[0], sizeof(stacks[0]), (void *)eventPort);
 
 	for (int i = 1; i < sizeof(stacks) / sizeof(stacks[0]); ++i) {
-		beginthread(posixsrvthr, 4, stacks[i], sizeof(stacks[i]), (void *)port);
+		beginthread(posixsrv_threadMain, 4, stacks[i], sizeof(stacks[i]), (void *)srvPort);
 	}
 
-	rq_timeoutthr(NULL);
+	posixsrv_threadRqTimeout(NULL);
 
 	/* never reached */
 	return 0;

--- a/srv.c
+++ b/srv.c
@@ -1,0 +1,64 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * POSIX server - standalone main
+ *
+ * Copyright 2018, 2023 Phoenix Systems
+ * Author: Jan Sikorski, Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/msg.h>
+#include <sys/threads.h>
+
+#include "posixsrv_private.h"
+
+#include "posixsrv.h"
+
+
+static char stacks[4][0x1000] __attribute__((aligned(8)));
+
+
+static int fail(const char *str)
+{
+	printf("posixsrv fail: %s\n", str);
+	exit(EXIT_FAILURE);
+}
+
+
+int main(int argc, char **argv)
+{
+	oid_t fs;
+	unsigned port;
+	unsigned events_port;
+
+	while (lookup("/", NULL, &fs) < 0) {
+		usleep(5000);
+	}
+
+	if (posixsrv_init(&port, &events_port) < 0) {
+		fail("srv init");
+	}
+
+	openlog("posixsrv", LOG_CONS, LOG_DAEMON);
+
+	beginthread(posixsrvthr, 4, stacks[0], sizeof(stacks[0]), (void *)events_port);
+
+	for (int i = 1; i < sizeof(stacks) / sizeof(stacks[0]); ++i) {
+		beginthread(posixsrvthr, 4, stacks[i], sizeof(stacks[i]), (void *)port);
+	}
+
+	rq_timeoutthr(NULL);
+
+	/* never reached */
+	return 0;
+}

--- a/tmpfile.c
+++ b/tmpfile.c
@@ -102,8 +102,8 @@ static request_t *tmpfile_fw_op(object_t *o, request_t *r)
 static request_t *tmpfile_close_op(object_t *o, request_t *r)
 {
 	TMP_TRACE("close operation");
-	object_destroy(o);
-	object_put(o);
+	posixsrv_object_destroy(o);
+	posixsrv_object_put(o);
 	return r;
 }
 
@@ -137,8 +137,8 @@ static int tmpfile_open(int *id)
 		return -ENOMEM;
 	}
 
-	object_create(&tmpfile->o, &tmpfile_ops);
-	*id = object_id(&tmpfile->o);
+	posixsrv_object_create(&tmpfile->o, &tmpfile_ops);
+	*id = posixsrv_object_id(&tmpfile->o);
 	asprintf(&path, "%s%d", TMPFILE_PATH, *id);
 
 	tmpfile->fd = open(path, O_RDWR | O_CREAT | O_TRUNC, DEFFILEMODE);
@@ -180,8 +180,8 @@ int tmpfile_init()
 	if ((o = malloc(sizeof(*o))) == NULL)
 		return -ENOMEM;
 
-	object_create(o, &tmpfile_server_ops);
-	err = object_link(o, "/dev/posix/tmpfile");
-	object_put(o);
+	posixsrv_object_create(o, &tmpfile_server_ops);
+	err = posixsrv_object_link(o, "/dev/posix/tmpfile");
+	posixsrv_object_put(o);
 	return err;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Adds ability to build `posixsrv` as `libposixsrv` (new feature) and/or standalone `posixsrv` (as before)

Because of the name resolution conflict during linking `libposixsrv` and `libdummyfs` in `imxrt-multi`, 
I had to change the names e.g. `object_get()` by adding prefix e.g. `posixsrv_object_get()`, if you like to make it `posixsrv_objectGet` let me know, I'll do that. These private functions can't be `static`, as well `__attribute__((visibility(".."))` would be no-go.

If you have any propositions of name changes it is good moment to point it, and I'll change it,

**changes may affect the DTR project.**

Because of posixsrv is started once (no two or more) - common state structure may be hidden in library. 

The public API `posixsrv.h` has been simplified to just 3 functions - (and example of use-case could be found in`srv.c` -  standalone server - name may change)

```C
int posixsrv_init(unsigned *srvPort, unsigned *eventPort);

/* user needs to  create few threads (one for events) */
void posixsrv_threadMain(void *arg);

/* user needs to create one thread */
void posixsrv_threadRqTimeout(void *arg);
```

If pipes, fifos, ptys should be created independently not in one function `posixsrv_init()`let me know.

I tried to keep-it-simple in use.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Possibility to use events, ptys and named fifos on medium size targets (imxrt family).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-evk`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
