### PR TITLE
pipe: reset buffer cursors when both ends are closed

### DIFF
--- a/pipe.c
+++ b/pipe.c
@@ -498,10 +498,20 @@ int pipe_close(pipe_t *p, unsigned flags, request_t *r)
 		}
 	}
 
-	if (!p->wrefs && !p->rrefs && !p->link) {
-		posixsrv_object_destroy(&p->object);
-		mutexUnlock(p->lock);
-		return EOK;
+	if (!p->wrefs && !p->rrefs) {
+		if (!p->link) {
+			posixsrv_object_destroy(&p->object);
+			mutexUnlock(p->lock);
+			return EOK;
+		}
+
+		if (p->w < p->r) {
+			p->w = p->r;
+		}
+		else {
+			p->r = p->w;
+		}
+		p->full = 0;
 	}
 
 	mutexUnlock(p->lock);


### PR DESCRIPTION
As specified by POSIX, after closing both ends of the FIFO, the
pipe contents should be cleared, which is not the case here before
this commit.

Fixes github.com/phoenix-rtos/phoenix-rtos-project/issues/1230

JIRA: RTOS-1282

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/473
- [X] I will merge this PR by myself when appropriate.
